### PR TITLE
Fix required version of freetype2

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -13,6 +13,8 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd libass-0.14.0/
+sed -i 's/9.10.3/2.9.1/' configure.ac
+autoreconf
 ./configure --prefix=$prefix --host=$target --disable-require-system-font-provider
 make -j${ncore}
 make install
@@ -43,9 +45,10 @@ products(prefix) = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "https://github.com/JuliaGraphics/FreeTypeBuilder/releases/download/v2.9.1/build_FreeType2.v2.9.0.jl",
+    "https://github.com/JuliaGraphics/FreeTypeBuilder/releases/download/v2.9.1-4/build_FreeType2.v2.10.0.jl",
     "https://github.com/SimonDanisch/FribidiBuilder/releases/download/0.14.0/build_fribidi.v0.14.0.jl",
-    "https://github.com/SimonDanisch/NASMBuilder/releases/download/2.13.3/build_nasm.v2.13.3.jl"
+    "https://github.com/staticfloat/Bzip2Builder/releases/download/v1.0.6-1/build_Bzip2.v1.0.6.jl",
+    "https://github.com/bicycle1885/ZlibBuilder/releases/download/v1.0.4/build_Zlib.v1.2.11.jl"
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
For the time being this fails because libbzip2 doesn't come with a pkg-config file :roll_eyes: 

*Update*: pkg-config file coming in https://github.com/staticfloat/Bzip2Builder/pull/2